### PR TITLE
fixing paramater for Get-ADDomain

### DIFF
--- a/GPOTools/functions/Register-GptDomainMapping.ps1
+++ b/GPOTools/functions/Register-GptDomainMapping.ps1
@@ -64,7 +64,7 @@
         }
         else {
             $params = @{
-                Domain = $Destination
+                Identity = $Destination
                 ErrorAction = 'Stop'
             }
             if ($Server) { $params['Server'] = $Server }


### PR DESCRIPTION
Fixes issue with Register-GptDomainMapping that would fail because it was using the wrong parameter for Get-ADDomain